### PR TITLE
React Router now works with gh-pages

### DIFF
--- a/quiz/src/index.js
+++ b/quiz/src/index.js
@@ -6,7 +6,7 @@ import App from './App';
 import registerServiceWorker from './registerServiceWorker';
 
 ReactDOM.render((
-	<BrowserRouter>
+	<BrowserRouter basename={process.env.PUBLIC_URL}>
 	  <App/>
 	</BrowserRouter>
   ), document.getElementById('root'));


### PR DESCRIPTION
Issue: #1 
`BrowserRouter` takes a `basename`-prop:
[Source](https://github.com/facebookincubator/create-react-app/issues/1765#issuecomment-327615099)